### PR TITLE
2d sprite mask to main

### DIFF
--- a/src/components/lume/YBillboard.tsx
+++ b/src/components/lume/YBillboard.tsx
@@ -30,12 +30,8 @@ export default function YBillboard(props: YBillboardProps) {
     let planeMaterial: THREE.MeshBasicMaterial | null = null;
     let yawRenderTask: RenderTask | null = null;
 
-    // Offscreen canvas used for alpha collision detection
-    // Super hacky, may want to replace with a more elegant solution in the future
-    let offscreenCanvas: HTMLCanvasElement | null = null;
-    let offscreenCtx: CanvasRenderingContext2D | null = null;
-    let imageBitmap: ImageBitmap | null = null;
-
+    // Array corresponding to sprite texture holding an opacity mask
+    // Used to restrict onClick to only opaque parts of the sprite.
     let alphaMask: Uint8Array | null = null;
     let maskWidth = 0;
     let maskHeight = 0;
@@ -84,30 +80,22 @@ export default function YBillboard(props: YBillboardProps) {
                     return;
                 }
 
-                // Create offscreen canvas representation of sprite. Used for opaque check
-                // on mouse events. TODO: Is this the most elegant way of doing this???
-                offscreenCanvas = document.createElement("canvas");
-                offscreenCtx = offscreenCanvas.getContext("2d", {willReadFrequently: true});
+                // Create an offscreen canvas to process image (get pixel data to build opacity mask)
+                const offscreenCanvas = document.createElement("canvas");
+                const offscreenCtx = offscreenCanvas.getContext("2d", {willReadFrequently: true});
                 offscreenCanvas.width = texture.image.width;
                 offscreenCanvas.height = texture.image.height
                 offscreenCtx!.drawImage(texture.image, 0, 0);
-                imageBitmap = await createImageBitmap(texture.image); // Convert texture to ImageBitmap for faster pixel access
-
-
                 const imgData = offscreenCtx!.getImageData(0, 0, offscreenCanvas.width, offscreenCanvas.height).data;
+
                 maskWidth = offscreenCanvas.width;
                 maskHeight = offscreenCanvas.height;
                 alphaMask = new Uint8Array(maskWidth * maskHeight);
                 
                 for (let i = 0; i < maskWidth * maskHeight; i++) {
                     const alpha = imgData[i * 4 + 3];
-                    alphaMask[i] = alpha > 25 ? 1 : 0; // Use your preferred threshold
+                    alphaMask[i] = alpha > 25 ? 1 : 0;
                 }
-
-                // Remove the canvas
-                offscreenCanvas = null;
-                offscreenCtx = null;
-
 
                 // Create and append actual mesh to scene.
                 const aspect = texture.image.width / texture.image.height;
@@ -128,12 +116,13 @@ export default function YBillboard(props: YBillboardProps) {
 
         // Attach Interaction Event Listeners.
         if(!wrapperRef?.three) return;
-        wrapperRef.three.userData.onHover = (uv: THREE.Vector2) => {
-            if (isOpaque(uv)) {
-                if(props.onHover) props.onHover(uv);
-            }
-        };
-
+        if(props.onHover) { // Only attach onHover if action defined (performance)
+            wrapperRef.three.userData.onHover = (uv: THREE.Vector2) => {
+                if (isOpaque(uv)) {
+                    if(props.onHover) props.onHover(uv);
+                }
+            };
+        }
         wrapperRef.three.userData.onClick = (uv: THREE.Vector2) => {
             if (isOpaque(uv)) {
                 if(props.onClick) props.onClick(uv);
@@ -157,19 +146,7 @@ export default function YBillboard(props: YBillboardProps) {
         planeMaterial = null;
         if(yawRenderTask) Motor.removeRenderTask(yawRenderTask);
 
-        // Need to dispose of offscreen canvas manually since we attach it to the document
-        if(offscreenCanvas) {
-            offscreenCanvas = null;
-        } 
-        if (offscreenCtx) {
-            offscreenCtx = null;
-        }
-
-        if (imageBitmap) {
-            imageBitmap.close();
-            imageBitmap = null;
-        }
-
+        alphaMask = null;
     });
 
     return (

--- a/src/components/lume/YBillboard.tsx
+++ b/src/components/lume/YBillboard.tsx
@@ -36,6 +36,10 @@ export default function YBillboard(props: YBillboardProps) {
     let offscreenCtx: CanvasRenderingContext2D | null = null;
     let imageBitmap: ImageBitmap | null = null;
 
+    let alphaMask: Uint8Array | null = null;
+    let maskWidth = 0;
+    let maskHeight = 0;
+
     function updateYawOnly() {
         if (!wrapperRef?.scene?.three || !plane) return;
     
@@ -59,18 +63,11 @@ export default function YBillboard(props: YBillboardProps) {
     }
 
     function isOpaque(uv: THREE.Vector2): boolean {
-        if (!offscreenCtx || !offscreenCanvas) return true; // Assume opaque if no canvas
-        if (!imageBitmap) return true; // Fallback if the image isn't ready yet
-    
-        // Convert UV coordinates (0 → 1) to pixel coordinates
-        const x = Math.floor(uv.x * offscreenCanvas.width);
-        const y = Math.floor((1 - uv.y) * offscreenCanvas.height); // Y is flipped from texture input.
-    
-        // Get pixel data from the canvas
-        const pixel = offscreenCtx.getImageData(x, y, 1, 1).data;
-        const alpha = pixel[3] / 255; // Normalize alpha to 0-1 range
-    
-        return alpha > 0.1; // Threshold to ignore nearly transparent pixels
+        if (!alphaMask) return true;
+        const x = Math.floor(uv.x * maskWidth);
+        const y = Math.floor((1 - uv.y) * maskHeight); // Flip Y axis
+        const index = y * maskWidth + x;
+        return alphaMask[index] === 1;
     }
 
     onMount(() => {
@@ -95,6 +92,22 @@ export default function YBillboard(props: YBillboardProps) {
                 offscreenCanvas.height = texture.image.height
                 offscreenCtx!.drawImage(texture.image, 0, 0);
                 imageBitmap = await createImageBitmap(texture.image); // Convert texture to ImageBitmap for faster pixel access
+
+
+                const imgData = offscreenCtx!.getImageData(0, 0, offscreenCanvas.width, offscreenCanvas.height).data;
+                maskWidth = offscreenCanvas.width;
+                maskHeight = offscreenCanvas.height;
+                alphaMask = new Uint8Array(maskWidth * maskHeight);
+                
+                for (let i = 0; i < maskWidth * maskHeight; i++) {
+                    const alpha = imgData[i * 4 + 3];
+                    alphaMask[i] = alpha > 25 ? 1 : 0; // Use your preferred threshold
+                }
+
+                // Remove the canvas
+                offscreenCanvas = null;
+                offscreenCtx = null;
+
 
                 // Create and append actual mesh to scene.
                 const aspect = texture.image.width / texture.image.height;


### PR DESCRIPTION
[YBillboard] replace permanent offscreen canvas with a more memory-efficient Uint8Array representing the opacity mask of a sprite.